### PR TITLE
chore: gitignore .claude/ (Claude Code per-session local state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ build
 venv/
 
 .github/copilot-instructions.md
+# Claude Code per-session local state (worktrees, scheduled-task locks,
+# settings.local.json) — agent-only, not source.
+.claude/


### PR DESCRIPTION
## Summary

Adds `.claude/` to `.gitignore` so per-session Claude Code state (skills, worktrees, scheduled-task locks, settings.local.json) doesn't pollute git status.

These directories are auto-generated by the cross-repo sync (`sync-copilot-to-claude.py` lives in `pangeachat/.github`) which now writes per-repo `.claude/skills/` instead of two centralized targets. The pattern matches what's already gitignored in `pangeachat/.github`.

## Test plan

- [x] `git status` after running the sync no longer shows `.claude/` as untracked